### PR TITLE
Corrections to playerColor values

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,53 +1,53 @@
 const playerColor = (color: number): string => {
     switch (color) {
         case 0:
-            return '#ff0000'
+            return '#ff0303'
         case 1:
-            return '#0000FF'
+            return '#0042ff'
         case 2:
-            return '#008080'
+            return '#1ce6b9'
         case 3:
-            return '#800080'
+            return '#540081'
         case 4:
-            return '#FFFF00'
+            return '#fffc00'
         case 5:
-            return '#FFA500'
+            return '#fe8a0e'
         case 6:
-            return '#008000'
+            return '#20c000'
         case 7:
-            return '#FFC0CB'
+            return '#e55bb0'
         case 8:
-            return '#808080'
+            return '#959697'
         case 9:
-            return '#ADD8E6'
+            return '#7ebff1'
         case 10:
-            return '#006400'
+            return '#106246'
         case 11:
-            return '#ADD8E6'
+            return '#4a2a04'
         case 12:
-            return '#800000'
+            return '#9b0000'
         case 13:
-            return '#000080'
+            return '#0000c3'
         case 14:
-            return '#40E0D0'
+            return '#00eaff'
         case 15:
-            return '#EE82EE'
+            return '#be00fe'
         case 16:
-            return '#F5DEB3'
+            return '#ebcd87'
         case 17:
-            return '#FFDAB9'
+            return '#f8a48b'
         case 18:
-            return '#F5FFFA'
+            return '#bfff80'
         case 19:
-            return '#E6E6FA'
+            return '#dcb9eb'
         case 20:
-            return '#3eb489'
+            return '#282828'
         case 21:
-            return '#FFFAFA'
+            return '#ebf0ff'
         case 22:
-            return '#50c878'
+            return '#00781e'
         case 23:
-            return '#D0B078'
+            return '#a46f33'
         default:
             return '000000'
     }

--- a/test/replays.test.ts
+++ b/test/replays.test.ts
@@ -93,7 +93,7 @@ describe('Replay parsing tests', () => {
         expect(test.version).toBe('1.29')
 
         expect(test.players[1].name).toBe('rudan')
-        expect(test.players[1].color).toBe('#3eb489')
+        expect(test.players[1].color).toBe('#282828')
         expect(test.observers.length).toBe(1)
         expect(test.matchup).toBe('NvN')
         expect(test.type).toBe('1on1')

--- a/test/replays.test.ts
+++ b/test/replays.test.ts
@@ -13,7 +13,7 @@ describe('Replay parsing tests', () => {
         expect(test.players[1].raceDetected).toBe('O')
         expect(test.players[1].id).toBe(4)
         expect(test.players[1].teamid).toBe(3)
-        expect(test.players[1].color).toBe('#50c878')
+        expect(test.players[1].color).toBe('#00781e')
         expect(test.players[1].units.summary).toEqual({
             opeo: 10, ogru: 5, ostr: 1, orai: 6, ospm: 5, okod: 2
         })
@@ -34,7 +34,7 @@ describe('Replay parsing tests', () => {
 
         expect(test.players[0].name).toBe('Stormhoof')
         expect(test.players[0].raceDetected).toBe('O')
-        expect(test.players[0].color).toBe('#800000')
+        expect(test.players[0].color).toBe('#9b0000')
         expect(test.players[0].id).toBe(6)
         expect(test.players[0].teamid).toBe(0)
         expect(test.players[0].units.summary).toEqual({
@@ -74,10 +74,10 @@ describe('Replay parsing tests', () => {
         expect(test.observers.length).toBe(8)
         expect(test.players[1].name).toBe('Happy_')
         expect(test.players[1].raceDetected).toBe('U')
-        expect(test.players[1].color).toBe('#0000FF')
+        expect(test.players[1].color).toBe('#0042ff')
         expect(test.players[0].name).toBe('u2.sok')
         expect(test.players[0].raceDetected).toBe('H')
-        expect(test.players[0].color).toBe('#ff0000')
+        expect(test.players[0].color).toBe('#ff0303')
         expect(test.matchup).toBe('HvU')
         expect(test.type).toBe('1on1')
         expect(test.players.length).toBe(2)


### PR DESCRIPTION
Some of the current color values are a bit off (15, 17, 18) and a couple are very wrong (11/brown is given the same value as 9/lightblue, 20/coal is given a kind of green/aqua). [See the differences in this codepen](https://codepen.io/bearand/pen/GRgMyMG).

Corrected values are based on [this data](https://docs.google.com/spreadsheets/d/1wzWIYzRW9pqpo1ZuEcU-qJTg-H4z5-PaTnHIXPezaRQ), from [HiveWorkshop](https://www.hiveworkshop.com/threads/wc3-editor-player-colors-reference.306608/)