### PR TITLE
adds checksumSha1 of map to parser output

### DIFF
--- a/src/W3GReplay.ts
+++ b/src/W3GReplay.ts
@@ -413,6 +413,7 @@ export default class W3GReplay extends EventEmitter {
         path: this.meta.map.mapName,
         file: convert.mapFilename(this.meta.map.mapName),
         checksum: this.meta.map.mapChecksum,
+        checksumSha1: this.meta.map.mapChecksumSha1,
       },
       version: convert.gameVersion(this.info.subheader.version),
       buildNumber: this.info.subheader.buildNo,

--- a/src/parsers/MetadataParser.ts
+++ b/src/parsers/MetadataParser.ts
@@ -65,6 +65,7 @@ type MapMetadata = {
   randomRaces: boolean;
   referees: boolean;
   mapChecksum: string;
+  mapChecksumSha1: string;
   mapName: string;
   creator: string;
 };
@@ -177,6 +178,8 @@ export default class MetadataParser extends StatefulBufferParser {
     parser.skip(0);
     const mapName = parser.readZeroTermString("utf-8");
     const creator = parser.readZeroTermString("utf-8");
+    parser.skip(1);
+    const checksumSha1 = parser.readStringOfLength(20, "hex");
     return {
       speed,
       hideTerrain: !!(secondByte & 0b00000001),
@@ -193,6 +196,7 @@ export default class MetadataParser extends StatefulBufferParser {
       mapName: mapName,
       creator: creator,
       mapChecksum: checksum,
+      mapChecksumSha1: checksumSha1,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ParserOutput {
     path: string;
     file: string;
     checksum: string;
+    checksumSha1: string;
   };
   buildNumber: number;
   version: string;

--- a/test/replays/126/replays.test.ts
+++ b/test/replays/126/replays.test.ts
@@ -19,6 +19,7 @@ it("parses a 2on2standard 1.29 replay properly", async () => {
   expect(test.players.length).toBe(4);
   expect(test.map).toEqual({
     checksum: "b4230d1e",
+    checksumSha1: "1f75e2a24fd995a6d7b123bb44d8afae7b5c6222",
     file: "w3arena__maelstrom__v2.w3x",
     path: "Maps\\w3arena\\w3arena__maelstrom__v2.w3x",
   });
@@ -43,6 +44,7 @@ it("parses a standard 1.26 replay properly", async () => {
   expect(test.players.length).toBe(2);
   expect(test.map).toEqual({
     checksum: "51a1c63b",
+    checksumSha1: "0b4f05ca7dcc23b9501422b4fa26a86c7d2a0ee0",
     file: "w3arena__amazonia__v3.w3x",
     path: "Maps\\w3arena\\w3arena__amazonia__v3.w3x",
   });

--- a/test/replays/129/replays.test.ts
+++ b/test/replays/129/replays.test.ts
@@ -16,6 +16,7 @@ it("parses a netease 1.29 replay properly", async () => {
   expect(test.players.length).toBe(2);
   expect(test.map).toEqual({
     checksum: "281f9d6a",
+    checksumSha1: "c232d68286eb4604cc66db42d45e28017b78e3c4",
     file: "(4)TurtleRock.w3x",
     path: "Maps/1.29\\(4)TurtleRock.w3x",
   });
@@ -89,6 +90,7 @@ it("parses a standard 1.29 replay with observers properly", async () => {
   expect(test.parseTime).toBe(Math.round(test.parseTime));
   expect(test.map).toEqual({
     checksum: "008ab7f1",
+    checksumSha1: "79ba7579f28e5ccfd741a1ebfbff95a56813086e",
     file: "w3arena__twistedmeadows__v3.w3x",
     path: "Maps\\w3arena\\w3arena__twistedmeadows__v3.w3x",
   });

--- a/test/replays/130/replays.test.ts
+++ b/test/replays/130/replays.test.ts
@@ -67,6 +67,7 @@ it("parses a standard 1.30 replay properly", async () => {
   expect(test.map).toEqual({
     file: "(4)TwistedMeadows.w3x",
     checksum: "c3cae01d",
+    checksumSha1: "23dc614cca6fd7ec232fbba4898d318a90b95bc6",
     path: "Maps\\FrozenThrone\\(4)TwistedMeadows.w3x",
   });
 });

--- a/test/schema.json
+++ b/test/schema.json
@@ -578,6 +578,26 @@
             "(4)TwistedMeadows.w3x"
           ],
           "pattern": "^(.*)$"
+        },
+        "checksum": {
+          "$id": "#/properties/map/properties/checksum",
+          "type": "string",
+          "title": "The Checksum Schema",
+          "default": "",
+          "examples": [
+            "b4230d1e"
+          ],
+          "pattern": "^(.*)$"
+        },
+        "checksumSha1": {
+          "$id": "#/properties/map/properties/checksumSha1",
+          "type": "string",
+          "title": "The ChecksumSha1 Schema",
+          "default": "",
+          "examples": [
+            "1f75e2a24fd995a6d7b123bb44d8afae7b5c6222"
+          ],
+          "pattern": "^(.*)$"
         }
       }
     },


### PR DESCRIPTION
Apparently the sha1 checksum of the map is more important nowadays when it comes to connecting the replay to the map file