### PR TITLE
update action parsing with findings from #197 for 2.0.2

### DIFF
--- a/src/parsers/ActionParser.ts
+++ b/src/parsers/ActionParser.ts
@@ -179,12 +179,13 @@ export default class ActionParser extends StatefulBufferParser {
           id: 0x79,
           action: this.buffer.slice(
             this.getOffset() - 1,
-            this.getOffset() + 0x11,
+            this.getOffset() + 0x14,
           ),
         } as const;
-        this.skip(0x11);
+        this.skip(0x14);
         return action;
       }
+      case 0x77:
       case 0x78:
         const identifier = this.readZeroTermString("utf8");
         const value = this.readZeroTermString("utf8");
@@ -480,11 +481,8 @@ export default class ActionParser extends StatefulBufferParser {
         this.skip(1);
         return null;
       }
-      case 0x77:
-        this.skip(13);
-        return null;
       case 0x7a:
-        this.skip(20);
+        this.skip(16);
         return null;
       case 0x7b:
         this.skip(16);


### PR DESCRIPTION
This should parse replays from 2.0.2 correctly (see #197). Additional testing on more replays might be necessary!