### PR TITLE
2.0.2 full parsing logic

### DIFF
--- a/src/parsers/ActionParser.ts
+++ b/src/parsers/ActionParser.ts
@@ -312,13 +312,13 @@ export type Action =
   | ArrowKeyAction;
 
 export default class ActionParser extends StatefulBufferParser {
-  parse(input: Buffer): Action[] {
+  parse(input: Buffer, post_202: boolean = false): Action[] {
     this.initialize(input);
     const actions: Action[] = [];
     while (this.getOffset() < input.length) {
       try {
         const actionId = this.readUInt8();
-        const action = this.parseAction(actionId);
+        const action = this.parseAction(actionId, post_202);
         if (action !== null) actions.push(action);
       } catch (ex) {
         console.log(ex);
@@ -341,8 +341,14 @@ export default class ActionParser extends StatefulBufferParser {
   }
 
   private oldActionId: number = 999999;
-  private parseAction(actionId: number): Action | null {
+  private parseAction(
+    actionId: number,
+    post_202: boolean = false,
+  ): Action | null {
     try {
+      if (post_202 && actionId > 0x77) {
+        actionId++;
+      }
       switch (actionId) {
         // no action 0x00
         case 0x1:
@@ -501,34 +507,34 @@ export default class ActionParser extends StatefulBufferParser {
           return { id: actionId, slotNumber, itemId };
         }
         // 0x20 to 0x4f are cheat actions
-        case 0x20:
-          break;
-        case 0x21:
-          this.skip(8);
-          break;
-        case 0x22:
-        case 0x23:
-        case 0x24:
-        case 0x25:
-        case 0x26:
-          break;
-        case 0x27:
-        case 0x28:
-          this.skip(5);
-          break;
-        case 0x29:
-        case 0x2a:
-        case 0x2b:
-        case 0x2c:
-          break;
-        case 0x2d:
-          this.skip(5);
-          break;
-        case 0x2e:
-          this.skip(4);
-          break;
-        case 0x2f:
-          break;
+        // case 0x20:
+        //   break;
+        // case 0x21:
+        //   this.skip(8);
+        //   break;
+        // case 0x22:
+        // case 0x23:
+        // case 0x24:
+        // case 0x25:
+        // case 0x26:
+        //   break;
+        // case 0x27:
+        // case 0x28:
+        //   this.skip(5);
+        //   break;
+        // case 0x29:
+        // case 0x2a:
+        // case 0x2b:
+        // case 0x2c:
+        //   break;
+        // case 0x2d:
+        //   this.skip(5);
+        //   break;
+        // case 0x2e:
+        //   this.skip(4);
+        //   break;
+        // case 0x2f:
+        //   break;
         // TODO: the rest of the cheats
 
         // END OF TODO
@@ -664,6 +670,8 @@ export default class ActionParser extends StatefulBufferParser {
             actionId,
             " after ",
             this.oldActionId,
+            " at offset ",
+            this.getOffset() - 1,
           );
           return null;
       }

--- a/src/parsers/GameDataParser.ts
+++ b/src/parsers/GameDataParser.ts
@@ -39,13 +39,16 @@ export type GameDataBlock =
 export default class GameDataParser extends EventEmitter {
   private actionParser: ActionParser;
   private parser: StatefulBufferParser;
+  private post_202: boolean = false;
+
   constructor() {
     super();
     this.actionParser = new ActionParser();
     this.parser = new StatefulBufferParser();
   }
 
-  async parse(data: Buffer): Promise<void> {
+  async parse(data: Buffer, post_202: boolean = false): Promise<void> {
+    this.post_202 = post_202;
     this.parser.initialize(data);
     while (this.parser.offset < data.length) {
       const block = this.parseBlock();
@@ -137,7 +140,7 @@ export default class GameDataParser extends EventEmitter {
         this.parser.offset,
         this.parser.offset + actionBlockLength,
       );
-      commandBlock.actions = this.actionParser.parse(actions);
+      commandBlock.actions = this.actionParser.parse(actions, this.post_202);
       this.parser.skip(actionBlockLength);
       commandBlocks.push(commandBlock as CommandBlock);
     }

--- a/src/parsers/MetadataParser.ts
+++ b/src/parsers/MetadataParser.ts
@@ -39,6 +39,7 @@ export type ReplayMetadata = {
   selectMode: string;
   gameName: string;
   startSpotCount: number;
+  post_202?: boolean;
 };
 
 type PlayerRecord = {
@@ -88,6 +89,7 @@ type MapMetadata = {
 export default class MetadataParser extends StatefulBufferParser {
   private mapmetaParser: StatefulBufferParser = new StatefulBufferParser();
 
+  private post_202: boolean = false;
   async parse(blocks: DataBlock[]): Promise<ReplayMetadata> {
     return this.parseData(await getUncompressedData(blocks));
   }
@@ -145,6 +147,7 @@ export default class MetadataParser extends StatefulBufferParser {
       selectMode,
       gameName,
       startSpotCount,
+      post_202: this.post_202,
     };
   }
 
@@ -170,7 +173,9 @@ export default class MetadataParser extends StatefulBufferParser {
     const result: ReforgedPlayerMetadata[] = [];
     const skinSet: Map<number, SkinData[]> = new Map();
     while (this.peekUInt8() === 0x38 || this.peekUInt8() === 0x39) {
-      this.skip(1);
+      if (this.readUInt8() === 0x38) {
+        this.post_202 = true;
+      }
       const subtype = this.readUInt8();
       const followingBytes = this.readUInt32LE();
       const data = this.buffer.subarray(

--- a/src/parsers/ReplayParser.ts
+++ b/src/parsers/ReplayParser.ts
@@ -48,7 +48,10 @@ export default class ReplayParser
       subheader: rawParserResult.subheader,
       metadata: metadataParserResult,
     });
-    await this.gameDataParser.parse(metadataParserResult.gameData);
+    await this.gameDataParser.parse(
+      metadataParserResult.gameData,
+      metadataParserResult.post_202!,
+    );
 
     return result;
   }


### PR DESCRIPTION
After more research in the world editor, the closest explanation is that they removed one of the sync actions' enum values, maybe it was 0x77, maybe it was 0x78, and since this coincides with them removing one of the core packets, type 0x38 being protobuf is the singular way to differentiate 2.0.2 from other 2.0.X, especially since they didn't remember to change editor version from 6115.

@diewolke9 I'd love to get your feedback on if this change enables you to open all replays with 0 "unknown action" errors 