### PR TITLE
fix(#206): switch console.log to console.error for errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,12 @@ export default defineConfig([
     },
 
     rules: {
+      "no-console": [
+        "error",
+        {
+          allow: ["warn", "error"],
+        },
+      ],
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "prettier": "^3.3.3",
         "ts-jest": "^29.2.5",
         "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "dist",
     "index.js"
   ],
+  "engines": {
+    "node": ">=18.x"
+  },
   "scripts": {
     "test": "jest --config test/jest.config.js",
     "test:coverage": "jest --collectCoverage --config test/jest.config.js",

--- a/src/W3GReplay.ts
+++ b/src/W3GReplay.ts
@@ -3,15 +3,16 @@ import convert from "./convert";
 import { objectIdFormatter, raceFlagFormatter } from "./parsers/formatters";
 import { ParserOutput } from "./types";
 import { sortPlayers } from "./sort";
-import { EventEmitter } from "events";
-import { createHash } from "crypto";
-import { performance } from "perf_hooks";
+import { EventEmitter } from "node:events";
+import console from "node:console";
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { readFile } from "node:fs";
+import { promisify } from "node:util";
 import ReplayParser, {
   ParserOutput as ReplayParserOutput,
   BasicReplayInformation,
 } from "./parsers/ReplayParser";
-import { readFile } from "fs";
-import { promisify } from "util";
 import {
   GameDataBlock,
   PlayerChatMessageBlock,
@@ -267,7 +268,7 @@ export default class W3GReplay extends EventEmitter implements W3GReplayEvents {
 
   processCommandDataBlock(block: CommandBlock): void {
     if (this.knownPlayerIds.has(String(block.playerId)) === false) {
-      console.log(
+      console.error(
         `detected unknown playerId in CommandBlock: ${block.playerId} - time elapsed: ${this.totalTimeTracker}`,
       );
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,10 @@ import W3GReplay from "./W3GReplay";
 
 import GameDataParser from "./parsers/GameDataParser";
 import MetadataParser from "./parsers/MetadataParser";
-import RawParser, { DataBlock, getUncompressedData } from "./parsers/RawParser";
+import RawParser, {
+  type DataBlock,
+  getUncompressedData,
+} from "./parsers/RawParser";
 import ReplayParser from "./parsers/ReplayParser";
 
 export default W3GReplay;
@@ -12,5 +15,5 @@ export {
   RawParser,
   ReplayParser,
   getUncompressedData,
-  DataBlock,
+  type DataBlock,
 };

--- a/src/parsers/ActionParser.ts
+++ b/src/parsers/ActionParser.ts
@@ -321,23 +321,11 @@ export default class ActionParser extends StatefulBufferParser {
         const action = this.parseAction(actionId);
         if (action !== null) actions.push(action);
       } catch (ex) {
-        console.log(ex);
+        console.error(ex);
         break;
       }
     }
     return actions;
-  }
-
-  private writeHexString(data: string) {
-    for (let i = 0; i < data.length; ) {
-      process.stdout.write(data[i] + data[i + 1]);
-      i += 2;
-      process.stdout.write(" ");
-      if (i % 32 == 0 && i < data.length) {
-        process.stdout.write("\n");
-      }
-    }
-    console.log();
   }
 
   private oldActionId: number = 999999;
@@ -659,7 +647,7 @@ export default class ActionParser extends StatefulBufferParser {
         case 0xa1:
           this.skip(9);
         default:
-          console.log(
+          console.error(
             "unknown action id ",
             actionId,
             " after ",

--- a/src/parsers/GameDataParser.ts
+++ b/src/parsers/GameDataParser.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 import StatefulBufferParser from "./StatefulBufferParser";
 import ActionParser from "./ActionParser";
 import { Action } from "./ActionParser";

--- a/src/parsers/MetadataParser.ts
+++ b/src/parsers/MetadataParser.ts
@@ -115,7 +115,7 @@ export default class MetadataParser extends StatefulBufferParser {
       reforgedPlayerMetadata = this.parseReforgedPlayerMetadata();
     }
     if (this.readUInt8() !== 25) {
-      console.log(
+      console.error(
         "Unknown chunk detected!",
         this.buffer.subarray(this.getOffset() - 1),
       );
@@ -124,7 +124,7 @@ export default class MetadataParser extends StatefulBufferParser {
     const slotRecordCount = this.readUInt8();
     // remaining bytes are: slotRecordCount(1), slots(9*count), seed(4), mode(1), spots(1)
     if (remainingBytes !== 1 + slotRecordCount * 9 + 6) {
-      console.log(
+      console.error(
         `Remaining bytes (${remainingBytes}) do not match expected bytes (${1 + slotRecordCount * 9 + 6})`,
       );
     }

--- a/src/parsers/RawParser.ts
+++ b/src/parsers/RawParser.ts
@@ -1,5 +1,5 @@
 import StatefulBufferParser from "./StatefulBufferParser";
-import { inflate, constants } from "zlib";
+import { inflate, constants } from "node:zlib";
 
 export type Header = {
   compressedSize: number;

--- a/src/parsers/ReplayParser.ts
+++ b/src/parsers/ReplayParser.ts
@@ -1,7 +1,7 @@
 import RawParser, { Header, SubHeader } from "./RawParser";
 import MetadataParser, { ReplayMetadata } from "./MetadataParser";
 import GameDataParser, { GameDataBlock } from "./GameDataParser";
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 
 export type ParserOutput = {
   header: Header;

--- a/test/replays/126/replays.test.ts
+++ b/test/replays/126/replays.test.ts
@@ -1,6 +1,6 @@
 import W3GReplay from "../../../src/";
-import path from "path";
-import fs from "fs";
+import path from "node:path";
+import fs from "node:fs";
 
 const Parser = new W3GReplay();
 it("parses a 2on2standard 1.29 replay properly", async () => {

--- a/test/replays/129/replays.test.ts
+++ b/test/replays/129/replays.test.ts
@@ -1,5 +1,5 @@
 import W3GReplay from "../../../src/";
-import path from "path";
+import path from "node:path";
 
 const Parser = new W3GReplay();
 it("parses a netease 1.29 replay properly", async () => {

--- a/test/replays/130/replays.test.ts
+++ b/test/replays/130/replays.test.ts
@@ -1,5 +1,5 @@
 import W3GReplay from "../../../src/";
-import path from "path";
+import path from "node:path";
 import { readFileSync } from "fs";
 import { Validator } from "jsonschema";
 import schema from "../../schema.json";

--- a/test/replays/131/replays.test.ts
+++ b/test/replays/131/replays.test.ts
@@ -1,5 +1,5 @@
 import W3GReplay from "../../../src/";
-import path from "path";
+import path from "node:path";
 
 const Parser = new W3GReplay();
 

--- a/test/replays/132/replays.test.ts
+++ b/test/replays/132/replays.test.ts
@@ -1,11 +1,21 @@
+import { jest, it } from "@jest/globals";
+import console from "node:console";
 import W3GReplay from "../../../src/";
-import path from "path";
+import path from "node:path";
 import {
   GameDataBlock,
   TimeslotBlock,
 } from "../../../src/parsers/GameDataParser";
 
 const Parser = new W3GReplay();
+let spiedConsoleError: jest.Spied<typeof console.error> | undefined = undefined;
+let spiedConsoleInfo: jest.Spied<typeof console.info> | undefined = undefined;
+
+afterEach(() => {
+  spiedConsoleError?.mockReset();
+  spiedConsoleInfo?.mockReset();
+});
+
 it("parses a reforged replay properly #1", async () => {
   const test = await Parser.parse(path.resolve(__dirname, "reforged1.w3g"));
   expect(test.version).toBe("1.32");
@@ -184,18 +194,60 @@ it("should return chat mode types correctly", async () => {
 });
 
 it("should handle a netease replay with rogue playerId 3 CommandDataBlocks correctly", async () => {
+  spiedConsoleError = jest.spyOn(console, "error").mockReturnValue();
+  spiedConsoleInfo = jest.spyOn(console, "info").mockReturnValue();
+
   const test = await Parser.parse(path.resolve(__dirname, "moju_vs_fly.nwg"));
+
   expect(test.players).toMatchSnapshot();
+  expect(spiedConsoleInfo).not.toHaveBeenCalled();
+  expect(spiedConsoleError).toHaveBeenCalledTimes(2);
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    1,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 66",
+  );
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    2,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 331452",
+  );
 });
 
 it("should handle a netease replay with rogue playerId 3 CommandDataBlocks correctly #2", async () => {
+  spiedConsoleError = jest.spyOn(console, "error").mockReturnValue();
+  spiedConsoleInfo = jest.spyOn(console, "info").mockReturnValue();
+
   const test = await Parser.parse(path.resolve(__dirname, "1582161008.nwg"));
+
   expect(test.players).toMatchSnapshot();
+  expect(spiedConsoleInfo).not.toHaveBeenCalled();
+  expect(spiedConsoleError).toHaveBeenCalledTimes(2);
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    1,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 66",
+  );
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    2,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 90750",
+  );
 });
 
 it("should handle a netease replay with rogue playerId 3 CommandDataBlocks correctly #3", async () => {
+  spiedConsoleError = jest.spyOn(console, "error").mockReturnValue();
+  spiedConsoleInfo = jest.spyOn(console, "info").mockReturnValue();
+
   const test = await Parser.parse(path.resolve(__dirname, "1582070968.nwg"));
+
   expect(test.players).toMatchSnapshot();
+  expect(spiedConsoleInfo).not.toHaveBeenCalled();
+  expect(spiedConsoleError).toHaveBeenCalledTimes(2);
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    1,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 66",
+  );
+  expect(spiedConsoleError).toHaveBeenNthCalledWith(
+    2,
+    "detected unknown playerId in CommandBlock: 3 - time elapsed: 294624",
+  );
 });
 
 it("should parse kotg as level 6", async () => {

--- a/test/replays/200/replays.test.ts
+++ b/test/replays/200/replays.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import W3GReplay, { MetadataParser, RawParser } from "../../../src";
-import path from "path";
+import path from "node:path";
 const Parser = new W3GReplay();
 
 it("recognizes a 'build haunted gold mine' command correctly and adds it to the player's buildings", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
-    "lib": ["es2018"],
-    "module": "commonjs",
-    "target": "es2018",
+    "moduleResolution": "node16",
+    "lib": ["es2023"],
+    "module": "node16",
+    "target": "es2022",
     "strict": true,
     "sourceMap": true,
     "declaration": true,
@@ -15,7 +15,9 @@
     "outDir": "dist/lib",
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "typeRoots": ["node_modules/@types"]
+    "typeRoots": ["node_modules/@types"],
+    "skipLibCheck": true,
+    "isolatedModules": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Closes #206 

~~Changes to the `example/output.json` were from the linter. These can be backed out and I will update the linter if it is necessary to be in the existing format.~~ Changes to the `example/output.json` are not linter related. See comment below.

Also made some small changes so that the typescript settings matched node versions that are supported by the test matrix in CI, as well as set it explicitly in the `package.json`  that the minimum node version is 18.x. Could bump to 20.x as 18.x is nearing end of life very soon.